### PR TITLE
Highlight active word cells

### DIFF
--- a/script.js
+++ b/script.js
@@ -74,6 +74,8 @@ const BASE_COLOUR_VALUES = {
   purple: '#c99cff'
 };
 const GREY_VALUE = '#bbb';
+// Temporary highlight colour for other cells in the active entry
+const ACTIVE_ENTRY_BG = '#eee';
 
 function key(r,c){ return `${r},${c}`; }
 
@@ -415,8 +417,11 @@ function setCurrentEntry(ent, fromCellKey=null){
 
 function highlightActive(){
   if (!currentEntry) return;
-  const cell = currentEntry.cells[currentEntry.iActive];
-  if (cell) cell.el.classList.add('active');
+  const active = currentEntry.cells[currentEntry.iActive];
+  currentEntry.cells.forEach(c => {
+    if (c !== active) c.el.style.background = ACTIVE_ENTRY_BG;
+  });
+  if (active) active.el.classList.add('active');
 }
 
 function handleCellClick(k){


### PR DESCRIPTION
## Summary
- Shade non-active cells of the current entry a light grey so the user can see the whole word

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c52e9b0530832b9953bbca35310129